### PR TITLE
Update nn-from-scratch.ipynb

### DIFF
--- a/nn-from-scratch.ipynb
+++ b/nn-from-scratch.ipynb
@@ -287,11 +287,11 @@
     "$$\n",
     "\\begin{aligned}\n",
     "& \\delta_3 = y - \\hat{y} \\\\\n",
-    "& \\delta_2 = (1 - \\tanh^2z_2) \\circ \\delta_3W_2^T \\\\\n",
+    "& \\delta_2 = (1 - \\tanh^2z_1) \\circ \\delta_3W_2^T \\\\\n",
     "& \\frac{\\partial{L}}{\\partial{W_2}} = a_1^T \\delta_3  \\\\\n",
     "& \\frac{\\partial{L}}{\\partial{b_2}} = \\delta_3\\\\\n",
-    "& \\frac{\\partial{L}}{\\partial{W_1}} = x^T \\delta2\\\\\n",
-    "& \\frac{\\partial{L}}{\\partial{b_1}} = \\delta2 \\\\\n",
+    "& \\frac{\\partial{L}}{\\partial{W_1}} = x^T \\delta_2\\\\\n",
+    "& \\frac{\\partial{L}}{\\partial{b_1}} = \\delta_2 \\\\\n",
     "\\end{aligned}\n",
     "$$"
    ]


### PR DESCRIPTION
Found a typo in the backpropagation formula in the ipython notebook file on line 290. It should be 1 - tanh^2(z1), rather than 1-tanh^2(z2). It is correctly implemented in the code below and even in the description in the blog post: http://www.wildml.com/2015/09/implementing-a-neural-network-from-scratch/. 

Also added subscripts to delta_2 on lines 293 and 294.
