### PR TITLE
Fixed the missing variables epsilon and reg_lambda

### DIFF
--- a/nn-from-scratch.ipynb
+++ b/nn-from-scratch.ipynb
@@ -314,7 +314,10 @@
     "num_examples = len(X) # training set size\n",
     "nn_input_dim = 2 # input layer dimensionality\n",
     "nn_output_dim = 2 # output layer dimensionality\n",
-    "\n"
+    "\n",
+    "# Gradient descent parameters (I picked these by hand)\n",
+    "epsilon = 0.01 # learning rate for gradient descent\n",
+    "reg_lambda = 0.01 # regularization strength"
    ]
   },
   {


### PR DESCRIPTION
This changes fixes the two missing variables **epsilon** and **reg_lambda** from the Jupyter notebook.
